### PR TITLE
Fix actions/cache caching Python 3.11 for the entire matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: pydeps-${{ hashFiles('**/poetry.lock') }}
+          key: pydeps-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       # Install dependencies. `--no-root` means "install all dependencies but not the project
       # itself", which is what you want to avoid caching _your_ code. The `if` statement

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local
-          key: poetry-1.1.12-0
+          key: poetry-${{ matrix.python-version }}
 
       # Install Poetry. You could do this manually, or there are several actions that do this.
       # `snok/install-poetry` seems to be minimal yet complete, and really just calls out to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,6 @@ packages = [{ include = 'randfacts' }]
 [tool.poetry.scripts]
 randfacts = 'randfacts.randfacts:_cli_entrypoint'
 
-[tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "function"
-
 [tool.pyright]
 reportUnusedCallResult = false
 


### PR DESCRIPTION
There's an issue where all of the Python versions that are being tested are using the Python 3.11 venv that's been cached.

This also removes the setting for pytest-asyncio from `pyproject.toml` as we don't use that pytest plugin. It must've been an artifact that happened while I was copying settings over from other projects